### PR TITLE
Fix discord invite link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -74,7 +74,7 @@ module.exports = {
           },
         ],
         permanent: false,
-        destination: "https://discord.gg/PdVnQY2TwM",
+        destination: "https://discord.gg/QcfPAJaWb2",
       },
     ];
   },


### PR DESCRIPTION
The current invite link does not exist anymore, I updated it with a new one with infinite duration.